### PR TITLE
Warning about unaudited code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ### x25519-chacha20poly1305
 
+---
+**WARNING: This code has not been audited and is not yet suitable for production. Use at your own risk.**
+
+---
+
 Nodejs package for x25519 key exchange and chacha20poly1305 encryption, written in Rust compiled to WASM.
 
 ## Development process


### PR DESCRIPTION
Since this package is published publicly (and at `yarn add x25519` none the less) we should definitely have a warning.