### PR TITLE
Enable static_secrets feature for x25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/entropyxyz/x25519-chacha20poly1305"
 hex = "*"
 bip39       ={ git="https://github.com/infincia/bip39-rs.git", tag="v0.6.0-beta.1" }
 wasm-bindgen = "0.2.83"
-x25519-dalek = "2.0.0-pre.1"
+x25519-dalek = { version = "2.0.0-pre.1", features = ["static_secrets"] }
 serde           ={ version="1.0", features=["derive"] }
 serde_json      ="1.0"
 blake2          ="0.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/entropyxyz/x25519-chacha20poly1305"
 hex = "*"
 bip39       ={ git="https://github.com/infincia/bip39-rs.git", tag="v0.6.0-beta.1" }
 wasm-bindgen = "0.2.83"
-x25519-dalek = { version = "2.0.0-pre.1", features = ["static_secrets"] }
+x25519-dalek = { version = "2.0.0-rc.2", features = ["static_secrets"] }
 serde           ={ version="1.0", features=["derive"] }
 serde_json      ="1.0"
 blake2          ="0.10.4"


### PR DESCRIPTION
The `x25519-dalek` version `2.0.0-rc.2` requires the `static_secrets` feature to be enabled in order to use [x25519_dalek](https://docs.rs/x25519-dalek/2.0.0-rc.2/x25519_dalek/index.html)::[StaticSecret](https://docs.rs/x25519-dalek/2.0.0-rc.2/x25519_dalek/struct.StaticSecret.html#).

I had to enable this feature to get this to build, even though we currently only have version `2.0.0-pre.1`.  

See https://docs.rs/crate/x25519-dalek/2.0.0-rc.2/features