### PR TITLE
Add function to create a SignedMessage without using types from sp-core version 6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,8 @@ impl SignedMessage {
     }
 
     /// Creates a `SignedMessage` without needing any types from sp-core
-    // This is useful for environments using newer versions of sp-core
+    ///
+    /// This is useful for environments using newer versions of sp-core
     pub fn new_with_keypair_seed(
         sr25519_keypair_seed: &[u8; 32],
         msg: Vec<u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,10 +207,10 @@ impl SignedMessage {
     pub fn new_with_keypair_seed(
         sr25519_keypair_seed: &[u8; 32],
         msg: Vec<u8>,
-        recip: &PublicKey,
+        recipient: &PublicKey,
     ) -> Result<Self, ValidationErr> {
         let pair = sr25519::Pair::from_seed(sr25519_keypair_seed);
-        Self::new(&pair, &Bytes(msg), recip)
+        Self::new(&pair, &Bytes(msg), recipient)
     }
 
     /// Decrypts the message and returns the plaintext.


### PR DESCRIPTION
Due to https://github.com/entropyxyz/x25519-chacha20poly1305/issues/15 we cannot use the `encrypt_and_sign` function from environments using `sp-core` / `subxt-signer`, so we need to use `SignedMessage` directly as we do in `entropy-core`.

This crate depends on `sp-core` version 6, as new versions don't compile to wasm.  Since `SignedMessage::new` has two arguments with types from `sp-core` this is inconvenient to use from crates which depend on a newer version of sp-core.

This PR adds an extra constructor which takes a 32 byte seed and generates a keypair from it internally, meaning the `Pair` type doesn't need to be given as an argument.

This is a hacky fix.  In the long term i would like to switch this crate to using `subxt-signer` but that will be a breaking change and until then i would like to do it this way.